### PR TITLE
Fix unused variable warnings

### DIFF
--- a/forwarder/pit.c
+++ b/forwarder/pit.c
@@ -34,6 +34,8 @@ static void ndn_pit_timeout(void *selfptr, size_t param_len, void *param){
   ndn_on_timeout_func on_timeout = NULL;
   void* userdata = NULL;
 
+  NDN_LOG_DEBUG("[PIT] timeout with pointer to parameter: %p and size: %d\n", (void*) param, param_len);
+
   for(i = 0; i < self->capacity; i ++){
     if(self->slots[i].nametree_id == NDN_INVALID_ID){
       continue;

--- a/ndn-error-code.h
+++ b/ndn-error-code.h
@@ -102,6 +102,7 @@
 #define NDN_SEC_INIT_FAILURE -28
 #define NDN_SEC_FAIL_VERIFY_SIG -29
 #define NDN_SEC_SIGNED_INTEREST_INVALID_DIGEST -30
+#define NDN_SEC_WRONG_INPUT_SIZE -31
 /* @} */
 
 /** @defgroup NDNErrorCodeFragmentation Fragmentation Errors

--- a/security/default-backend/ndn-lite-default-ecc-impl.c
+++ b/security/default-backend/ndn-lite-default-ecc-impl.c
@@ -147,6 +147,8 @@ ndn_lite_default_ecdsa_verify(const uint8_t* input_value, uint32_t input_size,
     return NDN_SEC_WRONG_KEY_SIZE;
   if (ecdsa_type != NDN_ECDSA_CURVE_SECP256R1)
     return NDN_SEC_UNSUPPORT_CRYPTO_ALGO;
+  if (input_size == 0)
+    return NDN_SEC_WRONG_INPUT_SIZE;
 
   uint8_t raw_sig_temp_buf[NDN_SEC_ECC_SECP256R1_PUBLIC_KEY_SIZE];
   uint32_t decoded_raw_signature_size;
@@ -176,6 +178,8 @@ ndn_lite_default_ecdsa_sign(const uint8_t* input_value, uint32_t input_size,
     return NDN_SEC_WRONG_KEY_SIZE;
   if (ecdsa_type != NDN_ECDSA_CURVE_SECP256R1)
     return NDN_SEC_UNSUPPORT_CRYPTO_ALGO;
+  if (input_size == 0)
+    return NDN_SEC_WRONG_INPUT_SIZE;
 
   uint32_t signature_size = NDN_SEC_ECC_SECP256R1_PUBLIC_KEY_SIZE;
   int ecc_sign_result = 0;

--- a/security/default-backend/ndn-lite-default-rng-impl.c
+++ b/security/default-backend/ndn-lite-default-rng-impl.c
@@ -8,6 +8,7 @@
  * See AUTHORS.md for complete list of NDN-LITE authors and contributors.
  */
 
+#include <stddef.h>
 #include "ndn-lite-default-rng-impl.h"
 #include "../ndn-lite-rng.h"
 #include "../../ndn-error-code.h"
@@ -15,6 +16,8 @@
 /* always fails and return 0 */
 static int ndn_lite_default_rng(uint8_t *dest, unsigned size)
 {
+    if (dest == NULL || size == 0)
+      return 0;
     return 0;
 }
 


### PR DESCRIPTION
The following variables are still unused when NDN_LOG_DEBUG is not enabled in the corresponding file:
- forwarder/pit.c:30:51: warning: unused parameter ‘param_len’
- forwarder/pit.c:30:68: warning: unused parameter ‘param’